### PR TITLE
feat: separate Node.js server and Python inference service for scalability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 env/
+node_modules/
+package-lock.json

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "axios": "^1.7.9",
+    "express": "^4.21.2"
+  }
+}

--- a/node/server.js
+++ b/node/server.js
@@ -1,0 +1,34 @@
+const express = require("express");
+const bodyParser = require("body-parser");
+const axios = require("axios");
+
+const app = express();
+const PORT = 3000;
+
+// Middleware to parse JSON
+app.use(bodyParser.json());
+
+// Route for prediction
+app.post("/predict", async (req, res) => {
+  try {
+    const inputData = req.body; // Expecting description, category, status
+    console.log("Input received:", inputData);
+
+    // Forward the input data to the Python ML service
+    const response = await axios.post(
+      "http://localhost:5000/predict",
+      inputData
+    );
+
+    // Return the prediction from the Python service
+    res.json(response.data);
+  } catch (error) {
+    console.error("Error in Node.js server:", error.message);
+    res.status(500).send({ error: error.message });
+  }
+});
+
+// Start the server
+app.listen(PORT, () => {
+  console.log(`Node.js server is running at http://localhost:${PORT}`);
+});

--- a/python/inference.py
+++ b/python/inference.py
@@ -5,11 +5,11 @@ import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 # Load the trained model and preprocessing tools
-model = joblib.load("inventory_recommender.pkl")
-vectorizer = joblib.load("tfidf_vectorizer.pkl")
-label_encoder_category = joblib.load("label_encoder_category.pkl")
-label_encoder_status = joblib.load("label_encoder_status.pkl")
-label_encoder_recommendation = joblib.load("label_encoder_recommendation.pkl")
+model = joblib.load("models/inventory_recommender.pkl")
+vectorizer = joblib.load("models/tfidf_vectorizer.pkl")
+label_encoder_category = joblib.load("models/label_encoder_category.pkl")
+label_encoder_status = joblib.load("models/label_encoder_status.pkl")
+label_encoder_recommendation = joblib.load("models/label_encoder_recommendation.pkl")
 
 # Input example
 input_data = {

--- a/python/ml_service.py
+++ b/python/ml_service.py
@@ -1,0 +1,88 @@
+from flask import Flask, request, jsonify
+import onnxruntime as ort
+import numpy as np
+import joblib
+
+# Initialize the app and ONNX runtime
+app = Flask(__name__)
+session = ort.InferenceSession("models/inventory_recommender.onnx")
+
+# Load TF-IDF Vectorizer and Label Encoders from .pkl files
+vectorizer = joblib.load("models/tfidf_vectorizer.pkl")
+label_encoder_category = joblib.load("models/label_encoder_category.pkl")
+label_encoder_status = joblib.load("models/label_encoder_status.pkl")
+label_encoder_recommendation = joblib.load("models/label_encoder_recommendation.pkl")
+
+# Encode categorical features
+def encode_category(category):
+    try:
+        return label_encoder_category.transform([category])[0]
+    except ValueError:
+        return -1  # Return an invalid value if the category is not found
+
+def encode_status(status):
+    try:
+        return label_encoder_status.transform([status])[0]
+    except ValueError:
+        return -1  # Return an invalid value if the status is not found
+
+# Decode the model's prediction
+def decode_prediction(prediction):
+    try:
+        return label_encoder_recommendation.inverse_transform([prediction])[0]
+    except ValueError:
+        return "Unknown"
+
+# Preprocess input
+def preprocess_input(data):
+    description = data["description"]
+    category = data["category"]
+    status = data["status"]
+
+    # Vectorize the description using TF-IDF
+    tfidf_vector = vectorizer.transform([description]).toarray()[0]
+    category_encoded = encode_category(category)
+    status_encoded = encode_status(status)
+
+    # Ensure valid inputs
+    if category_encoded == -1 or status_encoded == -1:
+        raise ValueError("Invalid category or status value")
+
+    # Combine features into a single vector
+    input_features = np.concatenate([tfidf_vector, [category_encoded, status_encoded]])
+
+    # Pad or trim the feature vector to match the expected input size of the ONNX model
+    expected_input_size = session.get_inputs()[0].shape[1]
+    if len(input_features) < expected_input_size:
+        input_features = np.pad(input_features, (0, expected_input_size - len(input_features)))
+    elif len(input_features) > expected_input_size:
+        input_features = input_features[:expected_input_size]
+
+    return input_features.astype(np.float32).reshape(1, -1)
+
+# Inference route
+@app.route("/predict", methods=["POST"])
+def predict():
+    try:
+        # Parse JSON input
+        data = request.json
+
+        # Preprocess input
+        input_features = preprocess_input(data)
+
+        # Run inference
+        input_name = session.get_inputs()[0].name
+        outputs = session.run(None, {input_name: input_features})
+        prediction = int(np.argmax(outputs[0]))  # Assuming classification model
+
+        # Decode prediction
+        recommendation = decode_prediction(prediction)
+
+        return jsonify({"recommendation": recommendation})
+    except ValueError as ve:
+        return jsonify({"error": str(ve)}), 400
+    except Exception as e:
+        return jsonify({"error": "An error occurred during inference", "details": str(e)}), 500
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/python/recommendation.py
+++ b/python/recommendation.py
@@ -9,6 +9,9 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report
 from imblearn.over_sampling import SMOTE
 import joblib
+import os
+
+model_directory = "models"
 
 # Step 1: Dataset
 data = {
@@ -139,10 +142,10 @@ cv_scores = cross_val_score(best_model, X_resampled, y_resampled, cv=5, scoring=
 print(f"K-Fold Cross Validation Accuracy: {cv_scores.mean():.4f} ± {cv_scores.std():.4f}")
 
 # Step 11: Save the Model and Preprocessing Tools
-joblib.dump(best_model, "inventory_recommender.pkl")
-joblib.dump(vectorizer, "tfidf_vectorizer.pkl")
-joblib.dump(label_encoder_category, "label_encoder_category.pkl")
-joblib.dump(label_encoder_status, "label_encoder_status.pkl")
-joblib.dump(label_encoder_recommendation, "label_encoder_recommendation.pkl")
+joblib.dump(best_model, os.path.join(model_directory, "inventory_recommender.pkl"))
+joblib.dump(vectorizer, os.path.join(model_directory, "tfidf_vectorizer.pkl"))
+joblib.dump(label_encoder_category, os.path.join(model_directory, "label_encoder_category.pkl"))
+joblib.dump(label_encoder_status, os.path.join(model_directory, "label_encoder_status.pkl"))
+joblib.dump(label_encoder_recommendation, os.path.join(model_directory, "label_encoder_recommendation.pkl"))
 
 print("Model, vectorizer, and label encoders saved.")


### PR DESCRIPTION
What was done:

    Implemented a clear separation of responsibilities between the Node.js server (frontend/backend) and the Python inference service.
    Added routes in the Node.js server to handle API requests and forward them to the Python ML service.
    Created a Python Flask service for preprocessing inputs, running ONNX model inference, and returning predictions.

Why this was done:

    To improve scalability, maintainability, and flexibility by decoupling the web server and the ML inference logic.
    To allow independent scaling of the services based on traffic or computational demand.